### PR TITLE
Introduce `RunSettings`, a global store of settings global to a single benchmark run

### DIFF
--- a/CoreGCBench.Analysis.Runner/Driver.cs
+++ b/CoreGCBench.Analysis.Runner/Driver.cs
@@ -129,20 +129,27 @@ namespace CoreGCBench.Analysis.Runner
             ComparisonAnalysisResult results = session.RunAnalysis();
             Logger.Log($"Analysis complete, writing to file: {opts.OutputFile}");
 
-            switch (opts.OutputType)
+            try
             {
-                case OutputType.Json:
-                    string json = JsonConvert.SerializeObject(results, Formatting.Indented);
-                    File.WriteAllText(opts.OutputFile, json);
-                    break;
-                case OutputType.Csv:
-                    using (StreamWriter writer = new StreamWriter(opts.OutputFile))
-                    {
-                        results.ToCsv(writer);
-                    }
-                    break;
-                default:
-                    throw new NotImplementedException("unimplemented output type: " + opts.OutputType);
+                switch (opts.OutputType)
+                {
+                    case OutputType.Json:
+                        string json = JsonConvert.SerializeObject(results, Formatting.Indented);
+                        File.WriteAllText(opts.OutputFile, json);
+                        break;
+                    case OutputType.Csv:
+                        using (StreamWriter writer = new StreamWriter(opts.OutputFile))
+                        {
+                            results.ToCsv(writer);
+                        }
+                        break;
+                    default:
+                        throw new NotImplementedException("unimplemented output type: " + opts.OutputType);
+                }
+            }
+            catch (IOException exn)
+            {
+                Logger.LogError($"Failed to write to disk: {exn.Message}");
             }
         }
     }

--- a/CoreGCBench.Analysis/AggregateDataSource.cs
+++ b/CoreGCBench.Analysis/AggregateDataSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CoreGCBench.Common;
 using System;
 using System.Collections.Generic;
 
@@ -14,11 +15,38 @@ namespace CoreGCBench.Analysis
     {
         private List<AnalysisDataSource> m_sources = new List<AnalysisDataSource>();
 
+        /// <summary>
+        /// The <see cref="RunSettings"/> used in the run that created these data sources.
+        /// Note that there's nothing that requires a user to use the same settings across
+        /// multiple runs - we'll emit a warning in that case and pick one of the settings
+        /// to store here.
+        /// </summary>
+        public RunSettings Settings { get; private set; } 
+
+        /// <summary>
+        /// Adds a data source to this AggregateDataSource.
+        /// </summary>
+        /// <param name="source">The data source to add</param>
         public void AddSource(AnalysisDataSource source)
         {
+            if (Settings != null && !source.Settings.Equals(Settings))
+            {
+                Logger.LogWarning("One of the given data sources used a different set of run settings than the others! The analysis results may be inaccurate.");
+            }
+
+            if (Settings == null)
+            {
+                Settings = source.Settings;
+            }
+
             m_sources.Add(source);
         }
 
+        /// <summary>
+        /// Enumerates all of the CoreCLR versions contained within this
+        /// aggregate data source.
+        /// </summary>
+        /// <returns>An enumeration of all </returns>
         public IEnumerable<VersionAnalysisDataSource> Versions()
         {
             foreach (var source in m_sources)

--- a/CoreGCBench.Analysis/AnalysisDataSource.cs
+++ b/CoreGCBench.Analysis/AnalysisDataSource.cs
@@ -37,6 +37,11 @@ namespace CoreGCBench.Analysis
         /// </summary>
         public IList<VersionAnalysisDataSource> Versions { get; set; } = new List<VersionAnalysisDataSource>();
 
+        /// <summary>
+        /// The run settings used in the run that created this data source.
+        /// </summary>
+        public RunSettings Settings { get; set; }
+
         public AnalysisDataSource(string zipFile)
         {
             Logger.Log($"Beginning data source construction for zip file {zipFile}");
@@ -46,6 +51,11 @@ namespace CoreGCBench.Analysis
 
             Logger.Log("Extracting zip file");
             ZipFile.ExtractToDirectory(zipFile, tempPath);
+
+            Logger.Log("Loading JSON result file");
+            var outputJson = Path.Combine(tempPath, Constants.OverallResultsJsonName);
+            RunResult result = JsonConvert.DeserializeObject<RunResult>(File.ReadAllText(outputJson));
+            Settings = result.Settings;
 
             // see the comment in CoreGCBench.Runner.Driver::PackageResults(RunResult, Options)
             // for a precise description of what the zip file looks like.

--- a/CoreGCBench.Analysis/AnalysisResult.cs
+++ b/CoreGCBench.Analysis/AnalysisResult.cs
@@ -12,6 +12,7 @@ namespace CoreGCBench.Analysis
 {
     public sealed class StandaloneAnalysisResult
     {
+        public RunSettings Settings { get; set; }
         public IList<StandaloneBenchmarkAnalysisResult> Benchmarks { get; set; } = new List<StandaloneBenchmarkAnalysisResult>();
     }
 
@@ -35,6 +36,7 @@ namespace CoreGCBench.Analysis
 
     public sealed class ComparisonAnalysisResult
     {
+        public RunSettings Settings { get; set; }
         public double PValue { get; set; }
         public IList<VersionComparisonAnalysisResult> Candidates { get; set; } = new List<VersionComparisonAnalysisResult>();
     }

--- a/CoreGCBench.Analysis/AnalysisSession.cs
+++ b/CoreGCBench.Analysis/AnalysisSession.cs
@@ -120,6 +120,7 @@ namespace CoreGCBench.Analysis
 
             return new ComparisonAnalysisResult
             {
+                Settings = m_dataSource.Settings,
                 PValue = m_pvalue,
                 Candidates = DoVersionComparisons(baseline).ToList()
             };

--- a/CoreGCBench.Runner/BenchmarkRun.cs
+++ b/CoreGCBench.Runner/BenchmarkRun.cs
@@ -34,6 +34,12 @@ namespace CoreGCBench.Runner
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public IList<CoreClrVersion> CoreClrVersions { get; set; } = new List<CoreClrVersion>();
+
+        /// <summary>
+        /// Settings for the benchmark run.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public RunSettings Settings { get; set; }
     }
 
     [Flags]

--- a/CoreGCBench.Runner/Driver.cs
+++ b/CoreGCBench.Runner/Driver.cs
@@ -199,9 +199,14 @@ namespace CoreGCBench.Runner
 
             Logger.LogAlways($"Wrote results to zip file: {zipFileName}");
 
-            // TODO(segilles) be VERY careful about this. not enabled until we're sure
-            // i'm not going to wreck my machine.
-            //Directory.Delete(options.OutputDirectory, true);
+            try
+            {
+                Directory.Delete(options.OutputDirectory, true);
+            }
+            catch (Exception exn)
+            {
+                Logger.LogWarning($"Failed to delete output directory: {exn.Message}");
+            }
         }
     }
 }

--- a/CoreGCBench.Runner/Shared/Benchmark.cs
+++ b/CoreGCBench.Runner/Shared/Benchmark.cs
@@ -35,22 +35,6 @@ namespace CoreGCBench.Common
         public string Arguments { get; set; } = null;
 
         /// <summary>
-        /// Whether or not this test uses Server GC. Defaults to false.
-        /// </summary>
-        [JsonProperty(
-            Required = Required.Default, 
-            NullValueHandling = NullValueHandling.Ignore)]
-        public bool? ServerGC { get; set; } = null;
-
-        /// <summary>
-        /// Whether or not this test uses Concurrent GC. Defaults to true.
-        /// </summary>
-        [JsonProperty(
-            Required = Required.Default, 
-            NullValueHandling = NullValueHandling.Ignore)]
-        public bool? ConcurrentGC { get; set; } = null;
-
-        /// <summary>
         /// Whether this test should end after some number of Gen0 GC's.
         /// </summary>
         [JsonProperty(

--- a/CoreGCBench.Runner/Shared/RunResult.cs
+++ b/CoreGCBench.Runner/Shared/RunResult.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace CoreGCBench.Common
@@ -13,7 +14,8 @@ namespace CoreGCBench.Common
     /// </summary>
     public sealed class RunResult
     {
-        public IDictionary<CoreClrVersion, CoreclrVersionRunResult> PerVersionResults { get; } = new Dictionary<CoreClrVersion, CoreclrVersionRunResult>();
+        public RunSettings Settings { get; set; }
+        public IList<Tuple<CoreClrVersion, CoreclrVersionRunResult>> PerVersionResults { get; } = new List<Tuple<CoreClrVersion, CoreclrVersionRunResult>>();
     }
 
     /// <summary>
@@ -74,7 +76,42 @@ namespace CoreGCBench.Common
                 && other.Path.Equals(Path);
         }
 
+        /// <summary>
+        /// Used by JSON.NET when (de)serializing this object.
+        /// </summary>
+        /// <returns>The name of this version.</returns>
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 
+    /// <summary>
+    /// Settings global to a benchmark run.
+    /// </summary>
+    public sealed class RunSettings : IEquatable<RunSettings>
+    {
+        /// <summary>
+        /// Whether or not this run should use Server GC.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public bool ServerGC { get; set; }
 
+        /// <summary>
+        /// Whether or not this run should use Concurrent GC.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public bool ConcurrentGC { get; set; }
+
+        public bool Equals(RunSettings other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return ServerGC == other.ServerGC
+                && ConcurrentGC == other.ConcurrentGC;
+        }
+    }
 }

--- a/CoreGCBench.Runner/example.json
+++ b/CoreGCBench.Runner/example.json
@@ -1,107 +1,14 @@
 ﻿{
+  "Settings": {
+    "ServerGC": false,
+    "ConcurrentGC": true
+  },
   "Suite": [
     {
       "Name": "ClientSimulator_Concurrent",
       "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\GCSimulator\\GCSimulator.exe",
       "Arguments": "-i 100",
-      "ServerGC": false,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "ClientSimulator_Server",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\GCSimulator\\GCSimulator.exe",
-      "Arguments": "-i 100",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "ClientSimulator_Server_One_Thread",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\GCSimulator\\GCSimulator.exe",
-      "Arguments": "-i 10 -notimer -dp 0.0",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "ClientSimulator_Server_Two_Threads",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\GCSimulator\\GCSimulator.exe",
-      "Arguments": "-i 10 -notimer -dp 0.0 -t 2",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "ClientSimulator_Server_Four_Threads",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\GCSimulator\\GCSimulator.exe",
-      "Arguments": "-i 10 -notimer -dp 0.0 -t 4",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "LargeStringConcat",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\LargeStrings\\LargeStrings.exe",
-      "Iterations": 10,
-      "ServerGC": false,
-      "ConcurrentGC": true
-    },
-    {
-      "Name": "LargeStringConcat_Server",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\LargeStrings\\LargeStrings.exe",
-      "ServerGC": true,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "MidLife_Concurrent",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\MidLife\\MidLife.exe",
-      "ServerGC": false,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "MidLife_Concurrent_Server",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\MidLife\\MidLife.exe",
-      "ServerGC": true,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "MidLife_Server",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\MidLife\\MidLife.exe",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "MidLife",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\MidLife\\MidLife.exe",
-      "ServerGC": false,
-      "ConcurrentGC": false,
-      "Iterations": 10
-    },
-    {
-      "Name": "ConcurrentSpin",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\ConcurrentSpin\\ConcurrentSpin.exe",
-      "ServerGC": false,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "ConcurrentSpin_Server",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\ConcurrentSpin\\ConcurrentSpin.exe",
-      "ServerGC": true,
-      "ConcurrentGC": true,
-      "Iterations": 10
-    },
-    {
-      "Name": "ConcurrentSpin_Server_NonConcurrent",
-      "ExecutablePath": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\GC\\Performance\\Tests\\ConcurrentSpin\\ConcurrentSpin.exe",
-      "ServerGC": true,
-      "ConcurrentGC": false,
-      "Iterations": 10
+      "Iterations": 5
     }
   ],
   "CollectionLevel": 0,


### PR DESCRIPTION
This PR introduces a `RunSettings` class on `BenchmarkRun` that groups all global settings that will be passed to the runner, porting `ServerGC` and `ConcurrentGC` to it. In the future, no changes will need to be made to the analysis library when settings are added - the only changes that will need to be made are in the runner itself, both in the definition of `RunSettings` and how the runner chooses to interpret the settings given to it.
