### PR TITLE
Add an environment field to the run result JSON that records some...

### DIFF
--- a/CoreGCBench.Runner/Runner.cs
+++ b/CoreGCBench.Runner/Runner.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace CoreGCBench.Runner
 {
@@ -72,6 +73,11 @@ namespace CoreGCBench.Runner
             ThrowIfCancellationRequested();
             RunResult result = new RunResult();
             result.Settings = m_run.Settings;
+            result.Environment = new RunEnvironment();
+            result.Environment.RunStartTime = DateTime.Now;
+            result.Environment.FrameworkDescription = RuntimeInformation.FrameworkDescription;
+            result.Environment.OperatingSystem = RuntimeInformation.OSDescription;
+            result.Environment.OSArchitecture = RuntimeInformation.OSArchitecture.ToString();
             Logger.LogAlways($"Running benchmarks with server GC: {m_run.Settings.ServerGC}");
             Logger.LogAlways($"Running benchmarks with concurrent GC: {m_run.Settings.ConcurrentGC}");
             foreach (var version in m_run.CoreClrVersions)

--- a/CoreGCBench.Runner/Shared/RunResult.cs
+++ b/CoreGCBench.Runner/Shared/RunResult.cs
@@ -14,7 +14,19 @@ namespace CoreGCBench.Common
     /// </summary>
     public sealed class RunResult
     {
+        /// <summary>
+        /// The settings used to perform the run.
+        /// </summary>
         public RunSettings Settings { get; set; }
+
+        /// <summary>
+        /// The environment in which the run was performed.
+        /// </summary>
+        public RunEnvironment Environment { get; set; }
+
+        /// <summary>
+        /// The results of the run, organized per version.
+        /// </summary>
         public IList<Tuple<CoreClrVersion, CoreclrVersionRunResult>> PerVersionResults { get; } = new List<Tuple<CoreClrVersion, CoreclrVersionRunResult>>();
     }
 
@@ -120,5 +132,34 @@ namespace CoreGCBench.Common
             return ServerGC == other.ServerGC
                 && ConcurrentGC == other.ConcurrentGC;
         }
+    }
+
+    /// <summary>
+    /// The environment in which the benchmark was run,
+    /// including the time, operating system, etc.
+    /// </summary>
+    public sealed class RunEnvironment 
+    {
+        /// <summary>
+        /// The date and time that the run began.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public DateTime RunStartTime { get; set; }
+
+        /// <summary>
+        /// The operating system used to perform the run. 
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string OperatingSystem { get; set; }
+
+        /// <summary>
+        /// A description of the framework that performed this run.
+        /// </summary>
+        public string FrameworkDescription { get; set; }
+
+        /// <summary>
+        /// The architecture of the operating system performing this run.
+        /// </summary>
+        public string OSArchitecture { get; set; }
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-dotnet restore CoreGCBench.Runner.Tests/project.json
-dotnet test CoreGCBench.Runner.Tests/project.json
+dotnet restore CoreGCBench.Runner/project.json
+dotnet build CoreGCBench.Runner/project.json


### PR DESCRIPTION
...information about the machine performing the benchmark run: the time the run was started, the OS, the architecture of the OS, and the framework version as reported by System.Runtime.

With this, the data recorded (on my OSX machine) looks like:

```
  "Environment": {
    "RunStartTime": "2016-09-09T13:33:54.626853-07:00",
    "OperatingSystem": "Darwin 15.4.0 Darwin Kernel Version 15.4.0: Fri Feb 26 22:08:05 PST 2016; root:xnu-3248.40.184~3/RELEASE_X86_64",
    "FrameworkDescription": ".NET Core 4.0.0.0",
    "OSArchitecture": "X64"
  }
```
