### PR TITLE
Support early termination of benchmark processes when...

### DIFF
--- a/CoreGCBench.Runner/Program.cs
+++ b/CoreGCBench.Runner/Program.cs
@@ -54,7 +54,7 @@ garbage collector.
             Console.CancelKeyPress += (obj, arg) =>
             {
                 arg.Cancel = true;
-                Logger.LogWarning("Cancellation requested via Ctrl-C, cleaning up...");
+                Logger.LogWarning("Cancellation requested via Ctrl-C, cleaning up... (may take up to 30 seconds!)");
                 cts.Cancel();
             };
 
@@ -81,7 +81,9 @@ garbage collector.
                 syntax.HandleHelp = false;
                 syntax.DefineOption("h|help", ref showHelp, "Displays this message.");
                 syntax.DefineOption("v|verbose", ref verbose, "Outputs additional verbose logging.");
+#if DEBUG
                 syntax.DefineOption("d|debug", ref veryVerbose, "Outputs very verbose logging, useful for debugging.");
+#endif
                 syntax.DefineOption("break-on-startup", ref breakOnStartup, "Launches a debugger on startup. Useful for debugging only.");
                 syntax.DefineParameter("configuration", ref configFile, "The configuration file to use to configure the benchmark run.");
 

--- a/CoreGCBench.Runner/Runner.cs
+++ b/CoreGCBench.Runner/Runner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CoreGCBench.Common;
+using CoreGCBench.Runner.Termination;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -10,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace CoreGCBench.Runner
 {
@@ -152,7 +154,10 @@ namespace CoreGCBench.Runner
             m_relativePath.Push(bench.Name);
             try
             {
-                return RunBenchmarkImplWithIterations(version, bench);
+                using (ITerminationCondition condition = ConstructTerminationCondition(bench))
+                {
+                    return RunBenchmarkImplWithIterations(version, bench, condition);
+                }
             }
             finally
             {
@@ -163,13 +168,31 @@ namespace CoreGCBench.Runner
         }
 
         /// <summary>
+        /// Given the Benchmark specification, determine the <see cref="TerminationCondition"/>
+        /// appropriate for this benchmark.
+        /// </summary>
+        /// <param name="bench">The benchmark specification</param>
+        /// <returns>An appropriate <see cref="TerminationCondition"/>, given the specification.</returns>
+        private ITerminationCondition ConstructTerminationCondition(Benchmark bench)
+        {
+            // TODO(#5) today, only time-specific terminations are supported.
+            if (bench.EndAfterTimeElapsedSeconds.HasValue)
+            {
+                return new TimeTerminationCondition(TimeSpan.FromSeconds(bench.EndAfterTimeElapsedSeconds.Value));
+            }
+
+            return new NullTerminationCondition();
+        }
+
+        /// <summary>
         /// Runs a single iteration of a benchmark. If no iteration number if specified,
         /// the benchmark is run once.
         /// </summary>
         /// <param name="version">The version of CoreCLR to run the benchmark on</param>
         /// <param name="bench">The benchmark to run</param>
+        /// <param name="termCondition">The termination condition for this benchmark</param>
         /// <returns>The result of running the benchmark</returns>
-        private BenchmarkResult RunBenchmarkImplWithIterations(CoreClrVersion version, Benchmark bench)
+        private BenchmarkResult RunBenchmarkImplWithIterations(CoreClrVersion version, Benchmark bench, ITerminationCondition termCondition)
         {
             ThrowIfCancellationRequested();
             Logger.LogAlways($"Running iterations for benchmark {bench.Name}");
@@ -192,7 +215,7 @@ namespace CoreGCBench.Runner
                     try
                     {
                         // we've got everything set up, time to run.
-                        iterResult = RunBenchmarkImpl(version, bench);
+                        iterResult = RunBenchmarkImpl(version, bench, termCondition);
                     }
                     finally
                     {
@@ -233,15 +256,11 @@ namespace CoreGCBench.Runner
         /// </summary>
         /// <param name="version">The coreclr version to test</param>
         /// <param name="bench">The benchmark to run</param>
+        /// <param name="termCondition">The termination condition for this benchmark</param>
         /// <returns>The result from running the benchmark</returns>
-        private IterationResult RunBenchmarkImpl(CoreClrVersion version, Benchmark bench)
+        private IterationResult RunBenchmarkImpl(CoreClrVersion version, Benchmark bench, ITerminationCondition termCondition)
         {
             ThrowIfCancellationRequested();
-            // TODO(segilles) we'd like to have precise control over when the benchmark
-            // terminates. After some number of GCs, after some mechanisms get exercised,
-            // after some amount of time elapses, etc. This can all be done here with
-            // some work.
-
             string coreRun = Path.Combine(version.Path, Utils.CoreRunName);
             string arguments = bench.Arguments ?? "";
             Debug.Assert(File.Exists(coreRun));
@@ -261,18 +280,72 @@ namespace CoreGCBench.Runner
             proc.StartInfo.Environment[Constants.ServerGCVariable] = m_run.Settings.ServerGC ? "1" : "0";
             proc.StartInfo.Environment[Constants.ConcurrentGCVariable] = m_run.Settings.ConcurrentGC ? "1" : "0";
 
-            Stopwatch timer = new Stopwatch();
-            timer.Start();
-            proc.Start();
-            proc.WaitForExit();
-            timer.Stop();
-            ThrowIfCancellationRequested();
+            // run the process!
+            RunProcess(termCondition, proc);
+            Debug.Assert(proc.HasExited);
 
             IterationResult result = new IterationResult();
-            result.DurationMsec = timer.ElapsedMilliseconds;
+            result.DurationMsec = (long)(proc.ExitTime - proc.StartTime).TotalMilliseconds;
             result.ExitCode = proc.ExitCode;
             result.Pid = proc.Id;
             return result;
+        }
+
+        /// <summary>
+        /// Starts the given process and polls it for completion. At every poll
+        /// interval, it asks the given <see cref="ITerminationCondition"/> if this
+        /// process needs to be killed, and kills it if needs to.
+        /// 
+        /// If the CancellationToken is signalled while in this method, the process
+        /// will be killed.
+        /// 
+        /// The process should not be running when this method exists.
+        /// </summary>
+        /// <param name="termCondition">The termination condition for this process</param>
+        /// <param name="proc">The unstarted process</param>
+        private void RunProcess(ITerminationCondition termCondition, Process proc)
+        {
+            proc.Start();
+            Logger.LogDiagnostic($"Started process: {proc.ProcessName} (pid {proc.Id}");
+            // once we start the process, we need to periodically poll it.
+            try
+            {
+                while (!proc.HasExited)
+                {
+                    Logger.LogDiagnostic("Beginning process exit poll");
+                    ThrowIfCancellationRequested();
+                    if (termCondition.ShouldTerminate(proc))
+                    {
+                        Logger.LogDiagnostic($"ITerminationCondition has requested that this process be terminated");
+                        // if we're asked to terminate the process, do so.
+                        try
+                        {
+                            proc.Kill();
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // According to MSDN, this is what gets thrown when you try to kill a process
+                            // that is not running.
+                            // Since our process could have died between the time we last
+                            // checked and now, just accept the exception and move on.
+                            // The end result is that the process isn't running anymore.
+                        }
+
+                        break;
+                    }
+
+                    // sleep for a second before polling again.
+                    Thread.Sleep(1000);
+                }
+
+                Logger.LogDiagnostic("Process has exited, exiting poll loop");
+            }
+            catch (OperationCanceledException)
+            {
+                // kill the process if we get Ctrl-C'd.
+                proc.Kill();
+                throw;
+            }
         }
 
         /// <summary>

--- a/CoreGCBench.Runner/Shared/Benchmark.cs
+++ b/CoreGCBench.Runner/Shared/Benchmark.cs
@@ -72,7 +72,7 @@ namespace CoreGCBench.Common
         [JsonProperty(
             Required = Required.Default, 
             NullValueHandling = NullValueHandling.Ignore)]
-        public int? EndAfterTimeElapsed { get; set; } = null;
+        public int? EndAfterTimeElapsedSeconds { get; set; } = null;
 
         /// <summary>
         /// The number of times to run the benchmark, averaging all data

--- a/CoreGCBench.Runner/Termination/ITerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/ITerminationCondition.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CoreGCBench.Runner.Termination
+{
+    /// <summary>
+    /// An ITerminationCondition is a class whose responsibility is to
+    /// determine, when asked, whether or not the running benchmark should terminate.
+    /// </summary>
+    public abstract class ITerminationCondition : IDisposable
+    {
+        /// <summary>
+        /// Asks this TerminationCondition whether or not it thinks it should terminate.
+        /// </summary>
+        /// <param name="proc">The Process that the termination condition should consider for termination.</param>
+        /// <returns>True if the process should be terminated.</returns>
+        public abstract bool ShouldTerminate(Process proc);
+
+        /// <summary>
+        /// Disposes this TerminationCondition. Does nothing unless overridden.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            // do nothing.
+        }
+    }
+}

--- a/CoreGCBench.Runner/Termination/NullTerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/NullTerminationCondition.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CoreGCBench.Runner.Termination
+{
+    /// <summary>
+    /// NullTerminationCondition does nothing and always returns false for <see cref="ShouldTerminate"/>.
+    /// This TerminationCondition is used by the runner when no termination condition is specified.
+    /// </summary>
+    public sealed class NullTerminationCondition : ITerminationCondition
+    {
+        public override bool ShouldTerminate(Process proc)
+        {
+            return false;
+        }
+    }
+}

--- a/CoreGCBench.Runner/Termination/TimeTerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/TimeTerminationCondition.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CoreGCBench.Runner.Termination
+{
+    /// <summary>
+    /// TimeTerminationCondition implements time-based termination. It will
+    /// signal a process for termination once it has run for a given period of time.
+    /// </summary>
+    public sealed class TimeTerminationCondition : ITerminationCondition
+    {
+        /// <summary>
+        /// The time span that the Process should be allowed to run,
+        /// after which the process should be terminated.
+        /// </summary>
+        private TimeSpan m_span;
+
+        /// <summary>
+        /// Constructs a new TimeTerminationCondition that will signal termination
+        /// at the end of the given number of seconds.
+        /// </summary>
+        /// <param name="proc">The process to observe</param>
+        /// <param name="span">The number of seconds after which this condition will
+        /// signal termination.</param>
+        public TimeTerminationCondition(TimeSpan span)
+        {
+            m_span = span;
+        }
+
+        /// <summary>
+        /// Signals termination once the process has been running m_seconds seconds.
+        /// </summary>
+        /// <param name="process">The Process to consider for termination.</param>
+        /// <returns>Whether or not this process should terminate.</returns>
+        public override bool ShouldTerminate(Process process)
+        {
+            return DateTime.Now - process.StartTime > m_span;
+        }
+    }
+}

--- a/CoreGCBench.Runner/Utilities.cs
+++ b/CoreGCBench.Runner/Utilities.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace CoreGCBench.Runner
@@ -62,9 +63,11 @@ namespace CoreGCBench.Runner
 
         /// <summary>
         /// Logs a message at the most verbose level, so it is only printed
-        /// if the -d option is given.
+        /// if the -d option is given on debug builds and is never printed
+        /// at all on release builds.
         /// </summary>
         /// <param name="fmt">A format string to print</param>
+        [Conditional("DEBUG")]
         public static void LogDiagnostic(string fmt)
         {
             Log(Verbosity.Diagnostic, fmt);


### PR DESCRIPTION
a condition is met. This commit implements the 'Time' condition,
where a process will be terminated if it has run for a period
of time specified by the benchmark.

This addresses part of https://github.com/swgillespie/CoreGCBench/issues/5 and lays the
foundation for more complex termination conditions than duration.
