### PR TITLE
Initial implementation of flexible binary submission.

### DIFF
--- a/CoreGCBench.Runner/PreparedCoreClrVersion.cs
+++ b/CoreGCBench.Runner/PreparedCoreClrVersion.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CoreGCBench.Common;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace CoreGCBench.Runner
+{
+    /// <summary>
+    /// A PreparedCoreClrVersion is a CoreClrVersion that has been prepared for execution.
+    /// A <see cref="CoreClrVersion"/> is not sufficient to execute a
+    /// version, because the user does not have to specify a full set of binaries in order
+    /// to perform a test run - they can supply a subset of the required binaries and the
+    /// infrastructure will draw the remaining binaries from a common source.
+    /// </summary>
+    public sealed class PreparedCoreClrVersion : IDisposable
+    {
+        /// <summary>
+        /// The CoreClrVersion that this PreparedCoreClrVersion was derived from.
+        /// </summary>
+        public CoreClrVersion OriginalVersion { get; private set; }
+
+        /// <summary>
+        /// The path to the prepared version, suitable to be consumed by the runner.
+        /// Everything that coreclr needs to run a binary should be in this folder.
+        /// </summary>
+        public string Path { get; private set; }
+
+        public string Name => OriginalVersion.Name;
+
+        /// <summary>
+        /// If we had to do something to prepare this version, we ended up creating
+        /// a temp directory. This means that we have to delete the directory
+        /// upon disposal.
+        /// </summary>
+        private bool m_createdATempDirectory;
+
+        /// <summary>
+        /// Creates a PreparedCoreClrVersion with the given version as the
+        /// "original" version and a path to the "fixed" version.
+        /// </summary>
+        /// <param name="version">The original version</param>
+        /// <param name="path">Path to the directory created for this version.
+        /// Must be a temporary path and will be deleted by this class upon disposal.</param>
+        public PreparedCoreClrVersion(CoreClrVersion version, string path)
+        {
+            Debug.Assert(version.IsPartial);
+            OriginalVersion = version;
+            Path = path;
+            m_createdATempDirectory = true;
+        }
+
+        /// <summary>
+        /// Creates a PreparedCoreClrVersion with the given version as
+        /// the "original" version and using the original version's path as
+        /// the path.
+        /// </summary>
+        /// <param name="version">The original version</param>
+        public PreparedCoreClrVersion(CoreClrVersion version)
+        {
+            Debug.Assert(!version.IsPartial);
+            OriginalVersion = version;
+            Path = version.Path;
+            m_createdATempDirectory = false;
+        }
+
+        /// <summary>
+        /// Best-effort attempt at deleting the temporary directory that got created
+        /// for this PreparedCoreClrVersion, if one was created.
+        /// </summary>
+        private void DisposeImpl()
+        {
+            if (m_createdATempDirectory)
+            {
+                Debug.Assert(OriginalVersion.IsPartial);
+                try
+                {
+                    Directory.Delete(Path);
+                }
+                catch (Exception exn)
+                {
+                    // best effort.
+                    Logger.LogWarning($"Failed to delete temporary version directory: {exn.Message}");
+                }
+
+                m_createdATempDirectory = false;
+            }
+        }
+
+        ~PreparedCoreClrVersion() {
+           DisposeImpl();
+        }
+
+        public void Dispose()
+        {
+            DisposeImpl();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/CoreGCBench.Runner/Shared/RunResult.cs
+++ b/CoreGCBench.Runner/Shared/RunResult.cs
@@ -69,6 +69,12 @@ namespace CoreGCBench.Common
         [JsonProperty(Required = Required.Always)]
         public string Path { get; set; }
 
+        [JsonProperty(Required = Required.DisallowNull)]
+        public List<string> Files { get; set; }
+
+        [JsonIgnore]
+        public bool IsPartial => Files != null;
+
         public override int GetHashCode()
         {
             int hash1 = Name.GetHashCode();
@@ -122,6 +128,20 @@ namespace CoreGCBench.Common
         [JsonProperty(Required = Required.Always)]
         public string TestProbeRoot { get; set; }
 
+        /// <summary>
+        /// If provided, is an absolute path to a folder to use to fill in the
+        /// files not provided by users when submitting a test run.
+        /// </summary>
+        [JsonProperty(Required = Required.Default)]
+        public string SharedBinaryFolder { get; set; }
+
+        /// <summary>
+        /// Two RunSettings are equal if a run can be reproduced
+        /// equivalently using both settings. Therefore, settings such as
+        /// TestProbeRoot and SharedBinaryFolder do /not/ count.
+        /// </summary>
+        /// <param name="other">The other RunSettings to evaluate</param>
+        /// <returns>Whether the two RunSettings are equal</returns>
         public bool Equals(RunSettings other)
         {
             if (other == null)
@@ -155,11 +175,13 @@ namespace CoreGCBench.Common
         /// <summary>
         /// A description of the framework that performed this run.
         /// </summary>
+        [JsonProperty(Required = Required.Always)]
         public string FrameworkDescription { get; set; }
 
         /// <summary>
         /// The architecture of the operating system performing this run.
         /// </summary>
+        [JsonProperty(Required = Required.Always)]
         public string OSArchitecture { get; set; }
     }
 }

--- a/CoreGCBench.Runner/Termination/NullTerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/NullTerminationCondition.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Diagnostics;
 
 namespace CoreGCBench.Runner.Termination

--- a/CoreGCBench.Runner/Termination/TerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/TerminationCondition.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics;
 
 namespace CoreGCBench.Runner.Termination

--- a/CoreGCBench.Runner/Termination/TimeTerminationCondition.cs
+++ b/CoreGCBench.Runner/Termination/TimeTerminationCondition.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics;
 
 namespace CoreGCBench.Runner.Termination

--- a/CoreGCBench.Runner/example.json
+++ b/CoreGCBench.Runner/example.json
@@ -2,7 +2,8 @@
   "Settings": {
     "ServerGC": false,
     "ConcurrentGC": true,
-    "TestProbeRoot": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release"
+    "TestProbeRoot": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release",
+    "SharedBinaryFolder": "E:\\GitHub\\coreclr\\bin\\tests\\Windows_NT.x64.Release\\Tests\\CoreRoot"
   },
   "Suite": [
     {
@@ -16,11 +17,13 @@
   "CoreClrVersions": [
     {
       "Name": "hww",
-      "Path": "E:\\GitHub\\CoreGCBench\\Samples\\baseline"
+      "Path": "E:\\GitHub\\CoreGCBench\\Samples\\baseline",
+      "Files": ["coreclr.dll"]
     },
     {
       "Name": "sww",
-      "Path": "E:\\GitHub\\CoreGCBench\\Samples\\candidate"
+      "Path": "E:\\GitHub\\CoreGCBench\\Samples\\candidate",
+      "Files": ["coreclr.dll"]
     }
   ]
 }


### PR DESCRIPTION
Users will be able to supply a subset of the binaries
produced as part of a CoreCLR build and the infrastructure
will draw all remaining binaries from a specified shared folder.
Fixes #13.
